### PR TITLE
Enable input after updating post

### DIFF
--- a/src/components/Post/Comment/Comment.js
+++ b/src/components/Post/Comment/Comment.js
@@ -6,7 +6,6 @@ import {
   CommentInput,
   CommentParagraph,
 } from "./Comment.style";
-import { updatePostById } from "../../../api/post";
 
 export default function Comment({ text, editModeState, update }) {
   const [editMode, setEditMode] = editModeState;
@@ -43,6 +42,7 @@ export default function Comment({ text, editModeState, update }) {
         () => {
           setEditMode(false);
           setParagraphText(newValue);
+          setDisabled((d) => false);
         },
         () => setDisabled((d) => false)
       );
@@ -62,7 +62,15 @@ export default function Comment({ text, editModeState, update }) {
           disabled={disabled}
         />
       ) : (
-        <CommentParagraph><ReactTagify tag={hashtags}  tagClicked={(tag) => handleTagClick(tag)} tagStyle={tagStyle}>{paragraphText}</ReactTagify></CommentParagraph>
+        <CommentParagraph>
+          <ReactTagify
+            tag={hashtags}
+            tagClicked={(tag) => handleTagClick(tag)}
+            tagStyle={tagStyle}
+          >
+            {paragraphText}
+          </ReactTagify>
+        </CommentParagraph>
       )}
     </CommentContainer>
   );


### PR DESCRIPTION
Resumo:
   Após atualizar um post o input continuava disabled = true. Agora ele volta a ser false apos a edição, permitindo uma nova edição sem a necessidade de atualizar a página.